### PR TITLE
Pin lib_rpl / lib_base to exact commits/versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,11 +44,16 @@ FetchContent_MakeAvailable(microsoft_gsl)
 # directory with no CMakeLists.txt so FetchContent_MakeAvailable() only
 # populates the sources and never calls add_subdirectory() on their own build
 # trees. This replaces the deprecated single-argument FetchContent_Populate().
+#
+# Pinned to exact commits (NOT a moving branch) so a build is reproducible and
+# a compromised/rewritten upstream master can't silently inject code into our
+# binary. To intentionally upgrade: bump the SHA below to a reviewed commit.
+# (GIT_SHALLOW is off for a pinned SHA — a shallow fetch of an arbitrary commit
+# is not reliably supported across Git hosts.)
 FetchContent_Declare(
     lib_rpl
     GIT_REPOSITORY https://github.com/desktop-app/lib_rpl.git
-    GIT_TAG        master
-    GIT_SHALLOW    TRUE
+    GIT_TAG        c57cccffb01d85570decd7fccb88419c9a682e63 # master @ 2026-07-20
     SOURCE_SUBDIR  _msga_no_configure
 )
 FetchContent_MakeAvailable(lib_rpl)
@@ -56,8 +61,7 @@ FetchContent_MakeAvailable(lib_rpl)
 FetchContent_Declare(
     lib_base
     GIT_REPOSITORY https://github.com/desktop-app/lib_base.git
-    GIT_TAG        master
-    GIT_SHALLOW    TRUE
+    GIT_TAG        82d182a275e197fd717fecc86193d9d91f4fc5b5 # master @ 2026-07-20
     SOURCE_SUBDIR  _msga_no_configure
 )
 FetchContent_MakeAvailable(lib_base)


### PR DESCRIPTION
FetchContent tracked GIT_TAG master, so every clean configure pulled whatever desktop-app/lib_{rpl,base} happened to be at — builds weren't reproducible and a rewritten/compromised upstream master could land in the binary unreviewed. Pin both to the current master commit; upgrading stays a one-line, reviewable SHA bump. GIT_SHALLOW is dropped because a shallow fetch of an arbitrary commit isn't reliably supported across Git hosts.

Better if we know exactly a tag or version to freeze to instead of a commit hash