### PR TITLE
Slack setup doc redirect URI to msga://oauth/callback

### DIFF
--- a/docs/SETUP_SLACK.md
+++ b/docs/SETUP_SLACK.md
@@ -71,8 +71,12 @@ In your app's settings, go to **OAuth & Permissions**.
 Under **Redirect URLs**, add exactly:
 
 ```
-http://localhost:17437/cb
+msga://oauth/callback
 ```
+
+This must match the redirect URI the client sends verbatim (see `kOAuthRedirectUri`
+in `src/backend/slack/oauth_flow.h`). Slack accepts this custom app scheme; the
+client receives the callback through its registered `msga://` URL handler.
 
 The **OAuth & Permissions** page has two scope lists: **Bot Token Scopes** and **User Token Scopes**. msga signs you in as *yourself* — it uses a **user token** (`xoxp-…`) only and never a bot token. Set the two lists accordingly.
 


### PR DESCRIPTION
The OAuth & Permissions guide told users to register http://localhost:17437/cb, but the client has always sent msga://oauth/callback (kOAuthRedirectUri in src/backend/slack/oauth_flow.h). 

Slack rejects a redirect that does not match verbatim, so anyone following the guide could not complete sign-in. 