### PR TITLE
Render :emoji: shortcodes in plain_text and link labels

### DIFF
--- a/src/backend/slack/json_mappers.cpp
+++ b/src/backend/slack/json_mappers.cpp
@@ -414,7 +414,13 @@ static TextWithEntities parseTextObj(const QJsonObject &o) {
     const auto text = o.value("text").toString();
     if (type == "mrkdwn")
         return MrkdwnParser::parse(text);
-    return TextWithEntities{text, {}};
+    // plain_text: no mrkdwn emphasis (*_~` stay literal), but Slack still expands
+    // :emoji: shortcodes — e.g. a bot header ":mega: Notification" — unless the
+    // object opts out with "emoji": false (default true). resolveTokens does the
+    // emoji pass and leaves marks alone; decodeEntities matches the title path.
+    if (o.value("emoji").toBool(true))
+        return MrkdwnParser::resolveTokens(MrkdwnParser::decodeEntities(text));
+    return TextWithEntities{MrkdwnParser::decodeEntities(text), {}};
 }
 
 // A button element — Block Kit shape ("text" is a plain_text object) or the

--- a/src/text/mrkdwn_parser.cpp
+++ b/src/text/mrkdwn_parser.cpp
@@ -38,10 +38,10 @@ struct Builder {
     // Append a recursively-parsed fragment, then wrap it in an outer span.
     // The outer entity is pushed BEFORE the shifted inner ones so that a
     // stable offset/length sort keeps the parent first for equal ranges.
-    void appendNested(EntityType type, const TextWithEntities &sub) {
+    void appendNested(EntityType type, const TextWithEntities &sub, const QString &data = {}) {
         const int start = static_cast<int>(text.size());
         text += sub.text;
-        entities.push_back(TextEntity{type, start, static_cast<int>(sub.text.size()), {}});
+        entities.push_back(TextEntity{type, start, static_cast<int>(sub.text.size()), data});
         for (auto e : sub.entities) {
             e.offset += start;
             entities.push_back(e);
@@ -153,6 +153,24 @@ static bool looksLikeUrl(const QString &s) {
            s.startsWith(QLatin1String("tel:"));
 }
 
+// Append `s`, adding an Emoji span per :name: shortcode. Link labels carry no
+// mrkdwn marks, but Slack's clients do render emoji in them (CI bots title
+// their notifications ":white_check_mark: …" inside a <url|label> token).
+static void appendPlainWithEmoji(Builder &b, const QString &s) {
+    static const QRegularExpression shortcode(QStringLiteral(":([a-zA-Z0-9_+\\-]+):"));
+    int  pos = 0;
+    auto it  = shortcode.globalMatch(s);
+    while (it.hasNext()) {
+        const auto m = it.next();
+        b.appendPlain(s.mid(pos, m.capturedStart() - pos));
+        const int start = b.text.size();
+        b.appendPlain(m.captured(0));
+        b.addSpan(EntityType::Emoji, start, m.captured(1));
+        pos = m.capturedEnd();
+    }
+    b.appendPlain(s.mid(pos));
+}
+
 // Append the resolved content of a single <…> construct: a user/channel
 // mention, an <!command> (incl. <!date^…>), or a <url|label> link. Mutates b.
 // When requireScheme is true a plain link is only linkified if its URL has a
@@ -226,11 +244,18 @@ static void appendAngleConstruct(Builder &b, const QString &inner, bool requireS
         b.appendPlain('<' + inner + '>');
         return;
     }
-    auto url         = decodeEntities(parts[0]);
-    auto label       = parts.size() > 1 ? decodeEntities(parts[1]) : url;
-    int  entityStart = b.text.size();
-    b.appendPlain(label);
-    b.addSpan(EntityType::Link, entityStart, url);
+    auto url   = decodeEntities(parts[0]);
+    auto label = parts.size() > 1 ? decodeEntities(parts[1]) : url;
+    // Emoji entities nest inside the Link span (the Link is pushed first so
+    // the parent-before-child order holds even when the label is one emoji).
+    // Bare <url> displays the URL itself — never emoji-scan that ("/a:b:c"
+    // path segments would false-match).
+    Builder sub;
+    if (parts.size() > 1)
+        appendPlainWithEmoji(sub, label);
+    else
+        sub.appendPlain(label);
+    b.appendNested(EntityType::Link, TextWithEntities{sub.text, sub.entities}, url);
 }
 
 // Recursion is bounded two ways. kMaxParseDepth is a hard backstop so crafted,

--- a/src/ui/message_list/message_render.cpp
+++ b/src/ui/message_list/message_render.cpp
@@ -1172,6 +1172,31 @@ QString buildMsgHtml(
     return wrapParagraph(toHtml(msg.text, session), "margin:0");
 }
 
+// Escaped inline HTML with ONLY emoji entities substituted; every other entity
+// renders as its plain text. For spots that can't take toHtml()'s full markup —
+// a linked attachment title puts the whole run inside one <a>, where a nested
+// anchor from a Link entity would be invalid.
+static QString emojiOnlyHtml(const TextWithEntities &twe, const Session *session) {
+    std::vector<const TextEntity *> emoji;
+    for (const auto &e : twe.entities)
+        if (e.type == EntityType::Emoji)
+            emoji.push_back(&e);
+    std::sort(emoji.begin(), emoji.end(), [](const TextEntity *a, const TextEntity *b) {
+        return a->offset < b->offset;
+    });
+    QString out;
+    int     pos = 0;
+    for (const TextEntity *e : emoji) {
+        if (e->offset < pos)
+            continue; // defensive: skip any overlapping span
+        out += QStringView{twe.text}.mid(pos, e->offset - pos).toString().toHtmlEscaped();
+        out += emojiHtml(resolveEmojiRich(e->data, session), inlineEmojiPx());
+        pos = e->offset + e->length;
+    }
+    out += QStringView{twe.text}.mid(pos).toString().toHtmlEscaped();
+    return out;
+}
+
 // Attachment text HTML (used inside the colored bar area).
 QString
 buildAttachHtml(const Attachment &att, const Session *session, const GifRenderContext *gif) {
@@ -1189,11 +1214,12 @@ buildAttachHtml(const Attachment &att, const Session *session, const GifRenderCo
             MrkdwnParser::resolveTokens(MrkdwnParser::decodeEntities(att.title));
         if (!att.titleLink.isEmpty())
             // The whole title is one link; embedded tokens collapse to their
-            // resolved plain text (anchors can't nest).
+            // resolved plain text (anchors can't nest) — except emoji, which
+            // substitute their glyph/img inline.
             html += "<p style='margin:0;font-weight:bold'><a href='" +
                     MrkdwnParser::decodeEntities(att.titleLink).toHtmlEscaped() +
                     "' style='color:" + Th::qss(Th::c().text.link) + ";text-decoration:none'>" +
-                    title.text.toHtmlEscaped() + "</a></p>";
+                    emojiOnlyHtml(title, session) + "</a></p>";
         else
             html += "<p style='margin:0;font-weight:bold'>" + toHtml(title, session) + "</p>";
     }

--- a/tests/test_json_mappers.cpp
+++ b/tests/test_json_mappers.cpp
@@ -735,6 +735,28 @@ TEST_CASE("toBlock header with plain_text", "[mappers][block]") {
     CHECK(b.text.entities.empty());
 }
 
+TEST_CASE("toBlock header plain_text expands :emoji: shortcodes", "[mappers][block]") {
+    // Bots (e.g. Amazon Q CodePipeline) put :mega: in a plain_text header block.
+    // Slack renders the emoji; the shortcode text stays but gets an Emoji entity.
+    auto b = JsonMappers::toBlock(obj(R"({
+        "type": "header",
+        "text": {"type": "plain_text", "text": ":mega: AWS CodePipeline Notification"}
+    })"));
+    CHECK(b.text.text == ":mega: AWS CodePipeline Notification");
+    REQUIRE(b.text.entities.size() == 1);
+    CHECK(b.text.entities[0].type == EntityType::Emoji);
+    CHECK(b.text.entities[0].data == "mega");
+}
+
+TEST_CASE("toBlock plain_text with emoji:false leaves shortcode literal", "[mappers][block]") {
+    auto b = JsonMappers::toBlock(obj(R"({
+        "type": "header",
+        "text": {"type": "plain_text", "text": ":mega: heads up", "emoji": false}
+    })"));
+    CHECK(b.text.text == ":mega: heads up");
+    CHECK(b.text.entities.empty());
+}
+
 TEST_CASE("toBlock image block", "[mappers][block]") {
     auto b = JsonMappers::toBlock(obj(R"({
         "type": "image",

--- a/tests/test_message_render.cpp
+++ b/tests/test_message_render.cpp
@@ -259,6 +259,19 @@ TEST_CASE("buildAttachHtml renders fields as bold title + value", "[render][atta
     CHECK(html.contains("Exceptional"));
 }
 
+TEST_CASE("buildAttachHtml linked title substitutes emoji shortcodes", "[render][attachment]") {
+    // CI bots (e.g. AWS CodePipeline via Amazon Q) put shortcodes in linked
+    // titles; the anchor can't take full mrkdwn but emoji must still resolve.
+    Attachment att;
+    att.title     = ":white_check_mark: AWS CodePipeline Notification";
+    att.titleLink = "https://console.aws.example/pipeline";
+    const QString html = MsgRender::buildAttachHtml(att, nullptr);
+    CHECK(html.contains("<a href='https://console.aws.example/pipeline'"));
+    CHECK(html.contains(QString::fromUtf8("✅"))); // ✅
+    CHECK(!html.contains("white_check_mark"));
+    CHECK(html.contains("AWS CodePipeline Notification"));
+}
+
 TEST_CASE("buildAttachHtml footer renders after fallback content", "[render][attachment]") {
     Attachment att;
     att.fallback       = "fb text";

--- a/tests/test_mrkdwn.cpp
+++ b/tests/test_mrkdwn.cpp
@@ -306,3 +306,26 @@ TEST_CASE("resolveTokens expands mention and emoji", "[mrkdwn]") {
     CHECK(r.entities[1].type == EntityType::Emoji);
     CHECK(r.entities[1].data == "wave");
 }
+
+TEST_CASE("link label resolves emoji shortcodes", "[mrkdwn]") {
+    // AWS CodePipeline (Amazon Q) sections: *<url|:white_check_mark: Title>*
+    auto r = MrkdwnParser::parse(
+        "*<https://console.aws.example/pipe|:white_check_mark: AWS CodePipeline Notification>*");
+    CHECK(r.text == ":white_check_mark: AWS CodePipeline Notification");
+    REQUIRE(r.entities.size() == 3);
+    // Parent-before-child: Bold wraps Link wraps Emoji.
+    CHECK(r.entities[0].type == EntityType::Bold);
+    CHECK(r.entities[1].type == EntityType::Link);
+    CHECK(r.entities[1].data == "https://console.aws.example/pipe");
+    CHECK(r.entities[2].type == EntityType::Emoji);
+    CHECK(r.entities[2].data == "white_check_mark");
+    CHECK(r.entities[2].offset == 0);
+    CHECK(r.entities[2].length == 18);
+}
+
+TEST_CASE("bare url label is never emoji-scanned", "[mrkdwn]") {
+    auto r = MrkdwnParser::parse("<https://example.com/a:b:c>");
+    CHECK(r.text == "https://example.com/a:b:c");
+    REQUIRE(r.entities.size() == 1);
+    CHECK(r.entities[0].type == EntityType::Link);
+}


### PR DESCRIPTION
Emoji resolution only ran on the mrkdwn path, so Slack message shapes that carry shortcodes elsewhere showed the raw :name: text:
  - plain_text objects (honouring "emoji": false), e.g. a bot header ":mega: Notification";
  - <url|label> link labels, e.g. AWS CodePipeline's *<url|:white_check_mark: Title>*;
  - linked attachment titles, where the anchor can't take full markup so only emoji are substituted inline. A bare <url> is deliberately not emoji-scanned (a /a:b:c path segment would false-match) — covered by a test. 
