### PR TITLE
Rewrite macOS notifications onto UNUserNotificationCenter + Dock badge

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -333,11 +333,13 @@ endif()
 # shared header; each degrades to the tray fallback when its API is unavailable.
 #   • Linux  — org.freedesktop.Notifications `image-data` hint via QtDBus
 #   • Windows — WinRT toast `appLogoOverride` (raw COM) + AUMID/shortcut/scheme
-#   • macOS  — NSUserNotification.contentImage (UserNotifications)
+#   • macOS  — UNUserNotificationCenter banner + attachment (UserNotifications);
+#             the same TU also sets the Dock tile badge (mac_app_badge.h)
 if(APPLE)
     target_sources(msga PRIVATE src/util/desktop_notifier_mac.mm)
     set_source_files_properties(src/util/desktop_notifier_mac.mm
         PROPERTIES SKIP_PRECOMPILE_HEADERS ON)
+    target_link_libraries(msga PRIVATE "-framework UserNotifications")
 elseif(WIN32)
     target_sources(msga PRIVATE src/util/desktop_notifier_win.cpp)
     # runtimeobject: WinRT (RoInitialize/RoGetActivationFactory/HSTRING).

--- a/src/ui/main_window.cpp
+++ b/src/ui/main_window.cpp
@@ -47,6 +47,9 @@
 #include "util/desktop_notifier.h"
 #include "util/slack_links.h"
 #include "util/sound_player.h"
+#ifdef Q_OS_MACOS
+#include "util/mac_app_badge.h"
+#endif
 
 #include <QDialog>
 #include <QEvent>
@@ -2291,6 +2294,13 @@ void MainWindow::updateTrayIcon() {
     }
     p.end();
     _trayIcon->setIcon(QIcon(px));
+
+#ifdef Q_OS_MACOS
+    // Dock tile badge: the actionable count (DM unreads + @mentions), matching
+    // Slack. Plain channel activity stays off the Dock (it still shows the tray
+    // tint and the in-app blue dot).
+    macSetDockBadge(globalMentions);
+#endif
 }
 
 // ── Workspace management ──────────────────────────────────────────────────────

--- a/src/util/desktop_notifier_mac.mm
+++ b/src/util/desktop_notifier_mac.mm
@@ -1,22 +1,51 @@
 #include "util/desktop_notifier.h"
+#include "util/mac_app_badge.h"
 
 #include <QBuffer>
 #include <QByteArray>
+#include <QDir>
 #include <QImage>
 
 #import <AppKit/AppKit.h>
 #import <Foundation/Foundation.h>
+#import <UserNotifications/UserNotifications.h>
 
-// NSUserNotification is deprecated (10.14) in favour of UserNotificationsUI, but
-// it still works, needs no extra entitlement/framework, and crucially tolerates
-// the unbundled dev binary (UNUserNotificationCenter throws without a bundle id).
-// It is also the only AppKit API that takes a per-notification picture
-// (contentImage, shown on the right) without the heavier UserNotifications setup.
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+// Notifications go through UNUserNotificationCenter (UserNotifications.framework).
+// The older NSUserNotification API this file used to call is not merely
+// deprecated: on modern macOS it delivers nothing and — the symptom that led
+// here — never registers the app under System Settings ▸ Notifications, so the
+// user has no permission toggle and never sees a banner. UNUserNotificationCenter
+// is the supported path; requesting authorization at startup is what registers
+// the app (creating the Settings entry) and prompts the user once.
+//
+// UNUserNotificationCenter requires a real, signed .app bundle with a bundle id
+// (CFBundleIdentifier) — currentNotificationCenter raises if the process is an
+// unbundled/unsigned binary. Our CMake bundle sets app.msga.msga and the build
+// ad-hoc signs the .app, so this is satisfied; the @try guard degrades to the
+// tray fallback (isAvailable()==false) anywhere it isn't.
+//
+// This file is compiled under manual reference counting (MRC, the project
+// default for Obj-C++), so retained objects are released explicitly.
 
-// Obj-C delegate that routes a notification click back to the C++ owner.
-@interface MsgaNotifDelegate : NSObject <NSUserNotificationCenterDelegate> {
+namespace {
+// Categories accumulate for the process lifetime: setNotificationCategories:
+// REPLACES the whole set, so we keep every category we've built and re-set the
+// union each time a new one appears. Keyed by category id so a repeat action
+// set is registered once. Never released (lives as long as the app).
+NSMutableDictionary<NSString *, UNNotificationCategory *> *g_categories = nil;
+
+// Stable category id for an ordered set of action keys, e.g. "msga.cat.join".
+NSString *categoryIdForActions(const QList<NotifAction> &actions) {
+    NSMutableArray<NSString *> *keys = [NSMutableArray array];
+    for (const auto &a : actions)
+        [keys addObject:a.key.toNSString()];
+    return [@"msga.cat." stringByAppendingString:[keys componentsJoinedByString:@"."]];
+}
+} // namespace
+
+// Delegate: presents banners while the app is frontmost and routes a click
+// (body or action button) back to the C++ owner as activated().
+@interface MsgaNotifDelegate : NSObject <UNUserNotificationCenterDelegate> {
     DesktopNotifier *_owner;
 }
 - (instancetype)initWithOwner:(DesktopNotifier *)owner;
@@ -28,38 +57,68 @@
         _owner = owner;
     return self;
 }
-// Show banners even when MSGA is frontmost (so the avatar always appears).
-- (BOOL)userNotificationCenter:(NSUserNotificationCenter *)center
-     shouldPresentNotification:(NSUserNotification *)notification {
-    return YES;
+
+// Show the banner even when MSGA is the active app (so the avatar always
+// appears). No sound here — the app plays its own configurable notification
+// sound (Sound::Player), and attaching one to the notification would double it.
+- (void)userNotificationCenter:(UNUserNotificationCenter *)center
+       willPresentNotification:(UNNotification *)notification
+         withCompletionHandler:(void (^)(UNNotificationPresentationOptions))completionHandler {
+    completionHandler(UNNotificationPresentationOptionBanner | UNNotificationPresentationOptionList);
 }
-- (void)userNotificationCenter:(NSUserNotificationCenter *)center
-       didActivateNotification:(NSUserNotification *)notification {
-    // The action button (when present) carries its own token; the body click
-    // (contents/other) falls back to the default token.
-    NSString *token = nil;
-    if (notification.activationType == NSUserNotificationActivationTypeActionButtonClicked)
-        token = notification.userInfo[@"actionToken"];
-    if (!token)
-        token = notification.userInfo[@"token"];
-    if (token && _owner)
+
+- (void)userNotificationCenter:(UNUserNotificationCenter *)center
+    didReceiveNotificationResponse:(UNNotificationResponse *)response
+             withCompletionHandler:(void (^)(void))completionHandler {
+    NSDictionary *info = response.notification.request.content.userInfo;
+    NSString     *aid  = response.actionIdentifier;
+    NSString     *token = nil;
+    if ([aid isEqualToString:UNNotificationDismissActionIdentifier]) {
+        // User swiped the banner away — nothing to open.
+    } else if ([aid isEqualToString:UNNotificationDefaultActionIdentifier]) {
+        token = info[@"token"]; // body click
+    } else {
+        // An action button — its per-button token was stashed under "action.<id>".
+        token = info[[@"action." stringByAppendingString:aid]];
+    }
+    if (token.length > 0 && _owner)
         _owner->emitActivated(QString::fromNSString(token));
+    completionHandler();
 }
 @end
 
 DesktopNotifier::DesktopNotifier(QObject *parent) : QObject(parent) {
-    NSUserNotificationCenter *center = [NSUserNotificationCenter defaultUserNotificationCenter];
+    UNUserNotificationCenter *center = nil;
+    @try {
+        center = [UNUserNotificationCenter currentNotificationCenter];
+    } @catch (NSException *e) {
+        // Raised for an unbundled/unsigned process — fall back to the tray.
+        NSLog(@"msga: UNUserNotificationCenter unavailable (%@) — using tray fallback", e.reason);
+        return;
+    }
     if (!center)
-        return; // no Notification Center (e.g. bare binary) → caller uses the tray
+        return;
+
     MsgaNotifDelegate *delegate = [[MsgaNotifDelegate alloc] initWithOwner:this];
-    center.delegate              = delegate; // assign (not retained) by the center
-    _delegate                    = delegate; // we hold the strong reference
-    _available                   = true;
+    center.delegate             = delegate; // assign (not retained) by the center
+    _delegate                   = delegate; // we hold the strong reference
+
+    // Registers the app under System Settings ▸ Notifications and prompts once.
+    // Badge is included so the app may set the Dock/notification badge; we never
+    // attach a sound (the app plays its own), but request it so the user's OS
+    // toggle for sound is meaningful should that change.
+    [center requestAuthorizationWithOptions:UNAuthorizationOptionAlert |
+                                            UNAuthorizationOptionSound | UNAuthorizationOptionBadge
+                          completionHandler:^(BOOL granted, NSError *error) {
+                              if (error)
+                                  NSLog(@"msga: notification authorization error: %@", error);
+                          }];
+    _available = true;
 }
 
 DesktopNotifier::~DesktopNotifier() {
     if (_delegate) {
-        NSUserNotificationCenter *center = [NSUserNotificationCenter defaultUserNotificationCenter];
+        UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
         if (center && center.delegate == (id)_delegate)
             center.delegate = nil;
         [(MsgaNotifDelegate *)_delegate release];
@@ -73,39 +132,78 @@ bool DesktopNotifier::notify(const QString &title, const QString &body, const QI
     if (!_available)
         return false;
 
-    NSUserNotification *note = [[[NSUserNotification alloc] init] autorelease];
-    note.title               = title.toNSString();
-    note.informativeText     = body.toNSString();
+    UNMutableNotificationContent *content = [[[UNMutableNotificationContent alloc] init] autorelease];
+    content.title                         = title.toNSString();
+    content.body                          = body.toNSString();
 
-    // NSUserNotification renders a single action button. Use the first action;
-    // stash both tokens so the delegate can tell a button click from a body one.
+    // userInfo carries the click tokens: the body token plus one per action
+    // button (keyed "action.<id>"), recovered by the delegate on click.
     NSMutableDictionary *info = [NSMutableDictionary dictionary];
     if (!token.isEmpty())
         info[@"token"] = token.toNSString();
-    if (!actions.isEmpty()) {
-        note.hasActionButton  = YES;
-        note.actionButtonTitle = actions.first().label.toNSString();
-        if (!actions.first().token.isEmpty())
-            info[@"actionToken"] = actions.first().token.toNSString();
-    }
-    if (info.count > 0)
-        note.userInfo = info;
 
+    UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
+    if (!actions.isEmpty()) {
+        NSString *catId = categoryIdForActions(actions);
+        if (!g_categories)
+            g_categories = [[NSMutableDictionary alloc] init];
+        if (!g_categories[catId]) {
+            NSMutableArray<UNNotificationAction *> *acts = [NSMutableArray array];
+            for (const auto &a : actions)
+                [acts addObject:[UNNotificationAction actionWithIdentifier:a.key.toNSString()
+                                                                    title:a.label.toNSString()
+                                                                  options:UNNotificationActionOptionForeground]];
+            UNNotificationCategory *cat =
+                [UNNotificationCategory categoryWithIdentifier:catId
+                                                       actions:acts
+                                             intentIdentifiers:@[]
+                                                       options:UNNotificationCategoryOptionNone];
+            g_categories[catId] = cat;
+            [center setNotificationCategories:[NSSet setWithArray:g_categories.allValues]];
+        }
+        content.categoryIdentifier = catId;
+        for (const auto &a : actions)
+            if (!a.token.isEmpty())
+                info[[@"action." stringByAppendingString:a.key.toNSString()]] = a.token.toNSString();
+    }
+    content.userInfo = info;
+
+    // Picture: UNNotificationAttachment needs a file URL, so spool the PNG to a
+    // temp file (the system copies it into its own store on schedule).
     if (!image.isNull()) {
         QByteArray png;
         QBuffer    buf(&png);
         buf.open(QIODevice::WriteOnly);
         if (image.save(&buf, "PNG")) {
-            NSData *data =
+            NSString *name =
+                [[[NSProcessInfo processInfo] globallyUniqueString] stringByAppendingString:@".png"];
+            NSString *path = [NSTemporaryDirectory() stringByAppendingPathComponent:name];
+            NSData   *data =
                 [NSData dataWithBytes:png.constData() length:static_cast<NSUInteger>(png.size())];
-            NSImage *img = [[[NSImage alloc] initWithData:data] autorelease];
-            if (img)
-                note.contentImage = img; // right-side thumbnail
+            if ([data writeToFile:path atomically:YES]) {
+                NSError *err = nil;
+                UNNotificationAttachment *att =
+                    [UNNotificationAttachment attachmentWithIdentifier:@"image"
+                                                                   URL:[NSURL fileURLWithPath:path]
+                                                               options:nil
+                                                                 error:&err];
+                if (att)
+                    content.attachments = @[att];
+            }
         }
     }
 
-    [[NSUserNotificationCenter defaultUserNotificationCenter] deliverNotification:note];
+    NSString *reqId = [[NSProcessInfo processInfo] globallyUniqueString];
+    UNNotificationRequest *req =
+        [UNNotificationRequest requestWithIdentifier:reqId content:content trigger:nil];
+    [center addNotificationRequest:req withCompletionHandler:nil];
     return true;
 }
 
-#pragma clang diagnostic pop
+// ── Dock tile badge (independent of notification authorization) ───────────────
+// setBadgeLabel needs no permission, so the Dock count works even when the user
+// has notifications turned off. Empty label clears the badge.
+void macSetDockBadge(int count) {
+    NSString *label = count > 0 ? [NSString stringWithFormat:@"%d", count] : nil;
+    [NSApp dockTile].badgeLabel = label;
+}

--- a/src/util/mac_app_badge.h
+++ b/src/util/mac_app_badge.h
@@ -1,0 +1,8 @@
+#pragma once
+
+// Set (or clear, when count <= 0) the macOS Dock tile badge — the red pill with
+// a number that the OS draws over the app's Dock icon. Independent of
+// notification authorization, so it works even when the user has denied
+// notifications. Implemented in desktop_notifier_mac.mm; the sole caller guards
+// it behind Q_OS_MACOS, so there is no non-mac implementation to link.
+void macSetDockBadge(int count);


### PR DESCRIPTION
The old NSUserNotification path is not just deprecated: on current macOS it delivers nothing and never registers the app under System Settings ▸ Notifications, so there is no permission toggle and no banners. 

Moved to UNUserNotificationCenter, which is the supported API — requesting authorization at startup is what registers the app and prompts the user once. 

Gains along the way: N action buttons per notification instead of one and a Dock tile badge (mac_app_badge.h) counting DM unreads + @mentions, which works even when notifications are denied (setBadgeLabel needs no authorization).

Depends on the bundle-identity change (app.msga.msga): UNUserNotificationCenter requires a signed bundle with a CFBundleIdentifier.