### PR TITLE
Show bot message content in notifications

### DIFF
--- a/src/ui/main_window.cpp
+++ b/src/ui/main_window.cpp
@@ -2028,7 +2028,7 @@ void MainWindow::maybeNotify(const QString &teamId, const EvMessageNew &ev) {
                : tr("Someone");
 
     // Resolve mentions/channels/emoji codes to friendly names for the OS toast.
-    const QString preview = MsgRender::notificationText(ev.msg.text, session);
+    const QString preview = MsgRender::notificationPreview(ev.msg, session);
 
     QString title, body;
     if (isDm) {

--- a/src/ui/message_list/message_render.cpp
+++ b/src/ui/message_list/message_render.cpp
@@ -295,7 +295,7 @@ QString notificationPreview(const Message &msg, const Session *session) {
     // blank. When `text` is empty, flatten the same block/attachment content the
     // message list renders into a short plain-text summary.
     const QString primary = notificationText(msg.text, session);
-    if (!primary.isEmpty())
+    if (!primary.trimmed().isEmpty())
         return primary;
 
     QStringList pieces;
@@ -313,6 +313,7 @@ QString notificationPreview(const Message &msg, const Session *session) {
 
     addBlocks(msg.blocks);
     for (const auto &att : msg.attachments) {
+        const int before = pieces.size();
         if (!att.pretext.isEmpty())
             add(MrkdwnParser::parse(att.pretext));
         if (!att.title.isEmpty())
@@ -322,13 +323,23 @@ QString notificationPreview(const Message &msg, const Session *session) {
             const QString val = notificationText(f.value, session).simplified();
             if (val.isEmpty())
                 continue;
-            pieces << (f.title.isEmpty() ? val : f.title.simplified() + ": " + val);
+            // Field titles are plain strings straight off the API, like the
+            // attachment title — decode their HTML escapes as the renderer does.
+            const QString key = MrkdwnParser::decodeEntities(f.title).simplified();
+            pieces << (key.isEmpty() ? val : key + ": " + val);
         }
         addBlocks(att.blocks);
         // Slack authors `fallback` precisely as the notification-safe summary, so
-        // it's the right last resort when an attachment had no richer text above.
-        if (pieces.isEmpty() && !att.fallback.isEmpty())
-            pieces << att.fallback.simplified();
+        // it's the right last resort when this attachment had no richer text above.
+        // It's mrkdwn like any other attachment text, so run it through the parser
+        // rather than showing raw "<url|label>" tokens in the toast. Skipped when
+        // the attachment renders something text can't carry (image, table block,
+        // buttons) — there Slack's fallback is a placeholder like "[no preview
+        // available]", which the message list drops for the same reason.
+        const bool rendersNonText =
+            !att.blocks.empty() || !att.imageUrl.isEmpty() || !att.buttons.empty();
+        if (pieces.size() == before && !rendersNonText && !att.fallback.isEmpty())
+            add(MrkdwnParser::parse(att.fallback));
     }
 
     return pieces.join(QStringLiteral(" · "));

--- a/src/ui/message_list/message_render.cpp
+++ b/src/ui/message_list/message_render.cpp
@@ -287,6 +287,53 @@ QString notificationText(const TextWithEntities &twe, const Session *session) {
     return out;
 }
 
+QString notificationPreview(const Message &msg, const Session *session) {
+    // The OS toast wants one line of readable text. A human's message carries it
+    // in `text`, so use that whenever it's there. Bot integrations (CodePipeline,
+    // Amazon Q, GitHub, …) instead leave `text` empty and put everything in Block
+    // Kit blocks or legacy attachments — which is why those toasts came through
+    // blank. When `text` is empty, flatten the same block/attachment content the
+    // message list renders into a short plain-text summary.
+    const QString primary = notificationText(msg.text, session);
+    if (!primary.isEmpty())
+        return primary;
+
+    QStringList pieces;
+    auto        add = [&](const TextWithEntities &twe) {
+        const QString t = notificationText(twe, session).simplified();
+        if (!t.isEmpty())
+            pieces << t;
+    };
+    // Block Kit: header/section/context/rich_text all carry displayable text.
+    // "image"/"divider"/"actions" blocks have none, so add() just skips them.
+    auto addBlocks = [&](const std::vector<Block> &blocks) {
+        for (const auto &b : blocks)
+            add(b.text);
+    };
+
+    addBlocks(msg.blocks);
+    for (const auto &att : msg.attachments) {
+        if (!att.pretext.isEmpty())
+            add(MrkdwnParser::parse(att.pretext));
+        if (!att.title.isEmpty())
+            add(MrkdwnParser::resolveTokens(MrkdwnParser::decodeEntities(att.title)));
+        add(att.text);
+        for (const auto &f : att.fields) {
+            const QString val = notificationText(f.value, session).simplified();
+            if (val.isEmpty())
+                continue;
+            pieces << (f.title.isEmpty() ? val : f.title.simplified() + ": " + val);
+        }
+        addBlocks(att.blocks);
+        // Slack authors `fallback` precisely as the notification-safe summary, so
+        // it's the right last resort when an attachment had no richer text above.
+        if (pieces.isEmpty() && !att.fallback.isEmpty())
+            pieces << att.fallback.simplified();
+    }
+
+    return pieces.join(QStringLiteral(" · "));
+}
+
 static QString escapeAndBr(const QString &s) {
     return s.toHtmlEscaped().replace("\n", "<br>");
 }

--- a/src/ui/message_list/message_render.h
+++ b/src/ui/message_list/message_render.h
@@ -76,6 +76,12 @@ QString toHtml(const TextWithEntities &twe, const Session *session = nullptr);
 // stay as ":name:"). No HTML, no markup — just readable text.
 QString notificationText(const TextWithEntities &twe, const Session *session);
 
+// Notification body for a whole message: the message text when it has any, and
+// otherwise a flattened summary of its Block Kit blocks / legacy attachments so
+// bot posts (CodePipeline, Amazon Q, GitHub, …) that leave `text` empty still
+// show their content in the OS toast instead of a bare "Bot:".
+QString notificationPreview(const Message &msg, const Session *session);
+
 // Geometry (doc coordinates, margins excluded) of every ``` code-block table in a
 // laid-out message document.
 QVector<QRectF> codeBlockRects(const QTextDocument *doc);

--- a/tests/test_message_render.cpp
+++ b/tests/test_message_render.cpp
@@ -742,3 +742,70 @@ TEST_CASE("notificationText leaves unknown custom emoji as a code", "[render][no
         MsgRender::notificationText(MrkdwnParser::parse("lunch? :no-lunch:"), nullptr);
     CHECK(out.contains(":no-lunch:"));
 }
+
+// ── notificationPreview (whole-message toast body) ────────────────────────────
+
+TEST_CASE("notificationPreview prefers the message text", "[render][notif]") {
+    Message msg;
+    msg.text = MrkdwnParser::parse("deploy finished");
+    Attachment att;
+    att.text = MrkdwnParser::parse("ignored");
+    msg.attachments.push_back(att);
+    CHECK(MsgRender::notificationPreview(msg, nullptr) == "deploy finished");
+}
+
+TEST_CASE(
+    "notificationPreview flattens Block Kit blocks of a textless bot post", "[render][notif]"
+) {
+    // The CodePipeline/Amazon Q shape: no `text`, everything in blocks.
+    Message msg;
+    Block   header;
+    header.typeStr = "header";
+    header.text    = TextWithEntities{"Pipeline failed", {}};
+    Block section;
+    section.typeStr = "section";
+    section.text    = MrkdwnParser::parse("stage *Deploy* on <#C1>");
+    msg.blocks      = {header, section};
+
+    auto         *session = renderSession();
+    const QString out     = MsgRender::notificationPreview(msg, session);
+    CHECK(out == QString::fromUtf8("Pipeline failed · stage Deploy on #general"));
+    delete session;
+}
+
+TEST_CASE("notificationPreview summarises attachment title, text and fields", "[render][notif]") {
+    Message    msg;
+    Attachment att;
+    att.title = "Build &amp; deploy";
+    att.text  = MrkdwnParser::parse("failed after 3m");
+    att.fields.push_back(AttachmentField{"Env &amp; region", MrkdwnParser::parse("prod")});
+    msg.attachments.push_back(att);
+
+    const QString out = MsgRender::notificationPreview(msg, nullptr);
+    CHECK(out == QString::fromUtf8("Build & deploy · failed after 3m · Env & region: prod"));
+}
+
+TEST_CASE("notificationPreview falls back to the attachment fallback text", "[render][notif]") {
+    Message    msg;
+    Attachment att;
+    att.fallback = "New build <https://ci.example/1|#1> ready";
+    msg.attachments.push_back(att);
+    // The fallback is mrkdwn: the link token resolves to its label, not raw markup.
+    CHECK(MsgRender::notificationPreview(msg, nullptr) == "New build #1 ready");
+}
+
+TEST_CASE(
+    "notificationPreview skips a placeholder fallback of a table attachment", "[render][notif]"
+) {
+    // Table messages carry "[no preview available]" as their fallback; the message
+    // list drops it, and the toast must not surface it either.
+    Message    msg;
+    Attachment att;
+    att.fallback = "[no preview available]";
+    Block blk;
+    blk.typeStr = "table";
+    blk.tableRows.push_back({TextWithEntities{"Header", {}}});
+    att.blocks.push_back(blk);
+    msg.attachments.push_back(att);
+    CHECK(MsgRender::notificationPreview(msg, nullptr).isEmpty());
+}


### PR DESCRIPTION
Bot integrations like AWS CodePipeline and Amazon Q leave a message's `text` field empty and put all their content in Block Kit blocks or legacy attachments. The OS notification body was built only from `text`, so those posts came through as a bare "#channel / Bot:" with no content.

Add MsgRender::notificationPreview(), which returns the message text when present and otherwise flattens the same block/attachment content the message list renders into a short plain-text summary. 

It walks header/section/context blocks, attachment pretext/title/text/fields and embedded blocks, and falls back to the attachment `fallback` (which Slack authors precisely as the notification-safe summary). 

The notification path now uses this instead of reading `text` directly.